### PR TITLE
Customize Android biometric prompt behavior

### DIFF
--- a/android/src/main/kotlin/design/codeux/biometric_storage/BiometricStoragePlugin.kt
+++ b/android/src/main/kotlin/design/codeux/biometric_storage/BiometricStoragePlugin.kt
@@ -125,7 +125,8 @@ class BiometricStoragePlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
                 val msg = call.argument<Map<String, Any>>("promptMessages")?.let { data ->
                     moshi.adapter(BiometricPromptMessages::class.java).fromJsonValue(data)
                 } ?: messages
-                authenticate(msg, {
+                val confirmationRequired = call.argument<Map<String, Any>>("confirmationRequired") as? Boolean ?: true
+                authenticate(msg, confirmationRequired, {
                     cb()
                 }) { info ->
                     result.error("AuthError:${info.error}", info.message.toString(), null)
@@ -191,7 +192,7 @@ class BiometricStoragePlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
             ?: throw Exception("Unknown response code {$response} (available: ${CanAuthenticateResponse.values()}")
     }
 
-    private fun authenticate(messages: BiometricPromptMessages, onSuccess: () -> Unit, onError: ErrorCallback) {
+    private fun authenticate(messages: BiometricPromptMessages, confirmationRequired: Boolean, onSuccess: () -> Unit, onError: ErrorCallback) {
         logger.trace("authenticate()")
         val activity = attachedActivity ?: return run {
             logger.error { "We are not attached to an activity." }
@@ -219,6 +220,7 @@ class BiometricStoragePlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
             .setSubtitle(messages.subtitle)
             .setDescription(messages.description)
             .setNegativeButtonText(messages.negativeButton)
+            .setConfirmationRequired(confirmationRequired)
             .build())
     }
 

--- a/android/src/main/kotlin/design/codeux/biometric_storage/BiometricStoragePlugin.kt
+++ b/android/src/main/kotlin/design/codeux/biometric_storage/BiometricStoragePlugin.kt
@@ -68,6 +68,7 @@ class BiometricStoragePlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
 
         const val PARAM_NAME = "name"
         const val PARAM_WRITE_CONTENT = "content"
+        const val PARAM_ANDROID_PROMPT_INFO = "androidPromptInfo"
 
         val moshi = Moshi.Builder()
             // ... add your own JsonAdapters and factories ...
@@ -78,7 +79,6 @@ class BiometricStoragePlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
     }
 
     private var attachedActivity: FragmentActivity? = null
-    private var messages = BiometricPromptMessages()
 
     private val storageFiles = mutableMapOf<String, BiometricStorageFile>()
 
@@ -110,6 +110,14 @@ class BiometricStoragePlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
 
             // every method call requires the name of the stored file.
             val getName = { requiredArgument<String>(PARAM_NAME) }
+            val getAndroidPromptInfo = {
+                requiredArgument<Map<String, Any>>(PARAM_ANDROID_PROMPT_INFO).let {
+                    moshi.adapter(AndroidPromptInfo::class.java).fromJsonValue(it) ?: throw MethodCallException(
+                        "BadArgument",
+                        "'$PARAM_ANDROID_PROMPT_INFO' is not well formed"
+                    )
+                }
+            }
 
             fun withStorage(cb: BiometricStorageFile.() -> Unit) {
                 val name = getName()
@@ -122,11 +130,8 @@ class BiometricStoragePlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
                 if (!options.authenticationRequired) {
                     return cb()
                 }
-                val msg = call.argument<Map<String, Any>>("promptMessages")?.let { data ->
-                    moshi.adapter(BiometricPromptMessages::class.java).fromJsonValue(data)
-                } ?: messages
-                val confirmationRequired = call.argument<Map<String, Any>>("confirmationRequired") as? Boolean ?: true
-                authenticate(msg, confirmationRequired, {
+                val promptInfo = getAndroidPromptInfo()
+                authenticate(promptInfo, {
                     cb()
                 }) { info ->
                     result.error("AuthError:${info.error}", info.message.toString(), null)
@@ -192,7 +197,7 @@ class BiometricStoragePlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
             ?: throw Exception("Unknown response code {$response} (available: ${CanAuthenticateResponse.values()}")
     }
 
-    private fun authenticate(messages: BiometricPromptMessages, confirmationRequired: Boolean, onSuccess: () -> Unit, onError: ErrorCallback) {
+    private fun authenticate(promptInfo: AndroidPromptInfo, onSuccess: () -> Unit, onError: ErrorCallback) {
         logger.trace("authenticate()")
         val activity = attachedActivity ?: return run {
             logger.error { "We are not attached to an activity." }
@@ -216,11 +221,11 @@ class BiometricStoragePlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
             }
         })
         prompt.authenticate(BiometricPrompt.PromptInfo.Builder()
-            .setTitle(messages.title)
-            .setSubtitle(messages.subtitle)
-            .setDescription(messages.description)
-            .setNegativeButtonText(messages.negativeButton)
-            .setConfirmationRequired(confirmationRequired)
+            .setTitle(promptInfo.title)
+            .setSubtitle(promptInfo.subtitle)
+            .setDescription(promptInfo.description)
+            .setNegativeButtonText(promptInfo.negativeButton)
+            .setConfirmationRequired(promptInfo.confirmationRequired)
             .build())
     }
 
@@ -249,9 +254,10 @@ class BiometricStoragePlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
     }
 }
 
-data class BiometricPromptMessages(
-    val title: String = "Authenticate to unlock data",
-    val subtitle: String? = null,
-    val description: String? = null,
-    val negativeButton: String = "Cancel"
+data class AndroidPromptInfo(
+    val title: String,
+    val subtitle: String?,
+    val description: String?,
+    val negativeButton: String,
+    val confirmationRequired: Boolean
 )

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -85,6 +85,8 @@ class _MyAppState extends State<MyApp> {
   final String baseName = 'default';
   BiometricStorageFile _authStorage;
   BiometricStorageFile _storage;
+  BiometricStorageFile _customPrompt;
+  BiometricStorageFile _noConfirmation;
 
   final TextEditingController _writeController =
       TextEditingController(text: 'Lorem Ipsum');
@@ -139,6 +141,21 @@ class _MyAppState extends State<MyApp> {
                         options: StorageFileInitOptions(
                           authenticationRequired: false,
                         ));
+                _customPrompt = await BiometricStorage().getStorage(
+                    '${baseName}_customPrompt',
+                    options: StorageFileInitOptions(
+                        authenticationValidityDurationSeconds: 30),
+                    promptMessages: PromptMessages(
+                      title: 'Custom title',
+                      subtitle: 'Custom subtitle',
+                      description: 'Custom description',
+                      negativeButton: 'Nope!',
+                    ));
+                _noConfirmation = await BiometricStorage().getStorage(
+                    '${baseName}_customPrompt',
+                    options: StorageFileInitOptions(
+                        authenticationValidityDurationSeconds: 30),
+                    confirmationRequired: false);
                 setState(() {});
                 _logger.info('initiailzed $baseName');
               },
@@ -156,6 +173,18 @@ class _MyAppState extends State<MyApp> {
                         style: TextStyle(fontWeight: FontWeight.bold)),
                     StorageActions(
                         storageFile: _storage,
+                        writeController: _writeController),
+                    const Divider(),
+                    const Text('Custom Authentication Prompt (Android)',
+                        style: TextStyle(fontWeight: FontWeight.bold)),
+                    StorageActions(
+                        storageFile: _customPrompt,
+                        writeController: _writeController),
+                    const Divider(),
+                    const Text('No Confirmation Prompt (Android)',
+                        style: TextStyle(fontWeight: FontWeight.bold)),
+                    StorageActions(
+                        storageFile: _noConfirmation,
                         writeController: _writeController),
                   ]),
             const Divider(),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -145,7 +145,7 @@ class _MyAppState extends State<MyApp> {
                     '${baseName}_customPrompt',
                     options: StorageFileInitOptions(
                         authenticationValidityDurationSeconds: 30),
-                    promptMessages: PromptMessages(
+                    androidPromptInfo: const AndroidPromptInfo(
                       title: 'Custom title',
                       subtitle: 'Custom subtitle',
                       description: 'Custom description',
@@ -155,7 +155,9 @@ class _MyAppState extends State<MyApp> {
                     '${baseName}_customPrompt',
                     options: StorageFileInitOptions(
                         authenticationValidityDurationSeconds: 30),
-                    confirmationRequired: false);
+                    androidPromptInfo: const AndroidPromptInfo(
+                      confirmationRequired: false,
+                    ));
                 setState(() {});
                 _logger.info('initiailzed $baseName');
               },

--- a/lib/src/biometric_storage.dart
+++ b/lib/src/biometric_storage.dart
@@ -71,7 +71,9 @@ class AndroidPromptInfo {
     this.description,
     this.negativeButton = 'Cancel',
     this.confirmationRequired = true,
-  });
+  })  : assert(title != null),
+        assert(negativeButton != null),
+        assert(confirmationRequired != null);
 
   final String title;
   final String subtitle;
@@ -81,31 +83,13 @@ class AndroidPromptInfo {
 
   static const _defaultValues = AndroidPromptInfo();
 
-  Map<String, dynamic> _toJson() {
-    final json = <String, dynamic>{};
-    if (title != null) {
-      json['title'] = title;
-    }
-
-    if (subtitle != null) {
-      json['subtitle'] = subtitle;
-    }
-
-    if (description != null) {
-      json['description'] = description;
-    }
-
-    if (negativeButton != null) {
-      json['negativeButton'] = negativeButton;
-    }
-
-    if (confirmationRequired != null) {
-      json['confirmationRequired'] = confirmationRequired;
-    }
-
-    return json;
-  }
-}
+  Map<String, dynamic> _toJson() => <String, dynamic>{
+        'title': title,
+        'subtitle': subtitle,
+        'description': description,
+        'negativeButton': negativeButton,
+        'confirmationRequired': confirmationRequired,
+      };
 
 class BiometricStorage {
   factory BiometricStorage() => _instance;


### PR DESCRIPTION
There is currently no way to customize the Android biometric prompt. This PR addresses to customizations:
- Messaging on the biometric prompt (which was already half way in place).
- Allowing a biometric prompt to not require user confirmation.
- Updated the example app to show usage without breaking backwards compatability.