### PR TITLE
Resolve iOS/MacOSX issue with reusing biometric access

### DIFF
--- a/macos/Classes/BiometricStorageImpl.swift
+++ b/macos/Classes/BiometricStorageImpl.swift
@@ -39,10 +39,9 @@ class BiometricStorageImpl {
   init(storageError: @escaping StorageError, storageMethodNotImplemented: Any) {
     self.storageError = storageError
     self.storageMethodNotImplemented = storageMethodNotImplemented
-    self.context = LAContext()
   }
   
-private var context:LAContext
+  private lazy var context: LAContext = LAContext()
   private var stores: [String: InitOptions] = [:]
   private let storageError: StorageError
   private let storageMethodNotImplemented: Any

--- a/macos/Classes/BiometricStorageImpl.swift
+++ b/macos/Classes/BiometricStorageImpl.swift
@@ -39,8 +39,10 @@ class BiometricStorageImpl {
   init(storageError: @escaping StorageError, storageMethodNotImplemented: Any) {
     self.storageError = storageError
     self.storageMethodNotImplemented = storageMethodNotImplemented
+    self.context = LAContext()
   }
   
+private var context:LAContext
   private var stores: [String: InitOptions] = [:]
   private let storageError: StorageError
   private let storageMethodNotImplemented: Any
@@ -118,6 +120,7 @@ class BiometricStorageImpl {
     query[kSecUseOperationPrompt as String] = promptInfo.accessTitle
     query[kSecReturnAttributes as String] = true
     query[kSecReturnData as String] = true
+    query[kSecUseAuthenticationContext as String] = context
     
     var item: CFTypeRef?
     
@@ -166,7 +169,6 @@ class BiometricStorageImpl {
     var query = baseQuery(name: name)
     
     if (initOptions.authenticationRequired) {
-      let context = LAContext()
       if initOptions.authenticationValidityDurationSeconds > 0 {
         if #available(OSX 10.12, *) {
           context.touchIDAuthenticationAllowableReuseDuration = Double(initOptions.authenticationValidityDurationSeconds)
@@ -230,7 +232,6 @@ class BiometricStorageImpl {
   }
   
   private func canAuthenticate(result: @escaping StorageCallback) {
-    let context = LAContext()
     if #available(iOS 10.0, OSX 10.12, *) {
       context.localizedCancelTitle = "Checking auth support"
     }


### PR DESCRIPTION
Related to:
https://github.com/authpass/biometric_storage/issues/15

LAContext MUST be reused for `touchIDAuthenticationAllowableReuseDuration` to work

And then correctly passed in: `query[kSecUseAuthenticationContext as String] = context` 

