### PR TITLE
Add a setting to allow biometric-only access on IOS.

### DIFF
--- a/lib/src/biometric_storage.dart
+++ b/lib/src/biometric_storage.dart
@@ -83,6 +83,7 @@ class StorageFileInitOptions {
     this.authenticationValidityDurationSeconds = -1,
     this.authenticationRequired = true,
     this.androidBiometricOnly = true,
+    this.iosBiometricOnly = false,
   });
 
   final int authenticationValidityDurationSeconds;
@@ -102,12 +103,17 @@ class StorageFileInitOptions {
   /// https://github.com/authpass/biometric_storage/issues/12#issuecomment-902508609
   final bool androidBiometricOnly;
 
+  /// Only makes difference on iOS, where if set true, you can't use
+  /// passcode to get the file.
+  final bool iosBiometricOnly;
+
   Map<String, dynamic> toJson() => <String, dynamic>{
         'authenticationValidityDurationSeconds':
             authenticationValidityDurationSeconds,
         'authenticationRequired': authenticationRequired,
         'androidBiometricOnly': androidBiometricOnly,
-      };
+        'iosBiometricOnly': iosBiometricOnly,
+  };
 }
 
 /// Android specific configuration of the prompt displayed for biometry.


### PR DESCRIPTION
* Make it possible to select storage that cannot be accessed by passcode in IOS. (iosBiometricOnly)
* To maintain backward compatibility, the default value is false.