### PR TITLE
Various bug fixes and new features for Android and iOS

### DIFF
--- a/android/src/main/kotlin/design/codeux/biometric_storage/BiometricStoragePlugin.kt
+++ b/android/src/main/kotlin/design/codeux/biometric_storage/BiometricStoragePlugin.kt
@@ -208,16 +208,9 @@ class BiometricStoragePlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
                 "canAuthenticate" -> result.success(canAuthenticate().name)
                 "init" -> {
                     val name = getName()
-                    if (storageFiles.containsKey(name)) {
-                        if (call.argument<Boolean>("forceInit") == true) {
-                            throw MethodCallException(
-                                "AlreadyInitialized",
-                                "A storage file with the name '$name' was already initialized."
-                            )
-                        } else {
-                            result.success(false)
-                            return
-                        }
+                    if (storageFiles.containsKey(name) && call.argument<Boolean>("forceInit") != true) {
+                        result.success(false)
+                        return
                     }
 
                     val options = call.argument<Map<String, Any>>("options")?.let { it ->

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: biometric_storage
 description: |
   Secure Storage: Encrypted data store optionally secured by biometric lock with support
   for iOS, Android, MacOS. Partial support for Linux, Windows and web (localStorage).
-version: 4.1.3
+version: 4.1.4
 homepage: https://github.com/authpass/biometric_storage/
 
 environment:


### PR DESCRIPTION
I've been working with a fork of this repo for some time now while developing my password manager, Kee Vault. The Android version is already in production and I'm working on the iOS version now so have a good understanding of what's required for both platforms. I've not looked at macOS or any other platforms and don't plan to do so in the short-term.

I think a lot, maybe all, of the changes I've developed will be useful for all package consumers so would like to help incorporate the work into this repo. I've created this PR with the full set of changes but appreciate there are a lot of separate concerns in there at the moment so am happy if you either cherry-pick specific commits or discuss the proposed changes in more detail here before we work on a number of more focussed PRs.

The PR contains the following changes, broken up into separate commits:

# Optional override of prompt info per request

An updated approach to that previously proposed in #13 so that a custom prompt can optionally be supplied to each action without having to re-initialise the storage every time.

# setRequestStrongBoxBacked (Android P+)

This improves security for Android P users and higher. I don't support any Android versions lower than that due to them being out of support with Google but previous simulator tests haven't revealed any issues with 8.0 and 8.1.

# Enable forceInit feature

I think this fixes a bug where asking to force the initialisation of the storage threw an exception rather than initialising it as requested.

# [ios] Remove "Checking auth support" Cancel button

The check to see if iOS can evaluate device owner authentication was setting the cancel button of the authentication context to always be "Checking auth support". This change just lets iOS use it's default ("Cancel" - that may be localised too but I've not checked).

# Fix ios authenticationValidityDurationSeconds

`touchIDAuthenticationAllowableReuseDuration` only applies to the biometric authentication which occurs when the user unlocks their device. At least that is the case with iOS 12 - I can't test on any other versions of macOS but the Apple documentation doesn't suggest we would expect a difference. https://developer.apple.com/documentation/localauthentication/lacontext/1622329-touchidauthenticationallowablere http://www.openradar.me/radar?id=6060524114542592

Thus we need to keep track of the time of last authentication ourselves and throw away the old LAContext instance when too much time has elapsed.

# Other commits

`Remove old code`, `Clarify comment`, `Upgrade build tools and Kotlin` and the version number increment should all be self-explanatory and hopefully not contentious but feel free to apply your own variation of these at a different time if that helps with your release process.

I'm looking forward to receiving your feedback regarding these changes @hpoul. If you or anyone else wants to try out the whole lot of them at once, https://github.com/kee-org/biometric_storage/tree/keevault is what I'm using for my app (https://github.com/kee-org/biometric_storage/commit/f94a7797c206582ee8ac68fbb1d45fda1f184172 at the time of writing).

