### PR TITLE
android: return correct code if no biometric is enrolled

### DIFF
--- a/android/src/main/kotlin/design/codeux/biometric_storage/BiometricStoragePlugin.kt
+++ b/android/src/main/kotlin/design/codeux/biometric_storage/BiometricStoragePlugin.kt
@@ -321,7 +321,7 @@ class BiometricStoragePlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
         val credentialsResponse = biometricManager.canAuthenticate(DEVICE_CREDENTIAL)
         logger.debug { "canAuthenticate for DEVICE_CREDENTIAL: $credentialsResponse" }
         if (credentialsResponse == BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED) {
-            return CanAuthenticateResponse.Success
+            return CanAuthenticateResponse.ErrorNoBiometricEnrolled
         }
 
         val response = biometricManager.canAuthenticate(


### PR DESCRIPTION
Returning success if we get an error from the underlying HW that no key is enrolled does not make sense, rather return the enum value designed for this case.

Closes: #104