### PR TITLE
enable building on jdk 17 and up

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,13 +25,18 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
-kotlin {
-    jvmToolchain(17)
-}
-
 android {
     namespace "design.codeux.biometric_storage"
     compileSdk 31
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = '17'
+    }
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'


### PR DESCRIPTION
This change makes it possible to build biometric_storage for Android with any JDK >= 17. Without this change 17 is required, preventing it to be build on e.g JDK 21.

closes #117