### PR TITLE
Add flag forceBiometricAuthentication android & iOS 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.1.1-dev.2
+
+* Add flag `forceBiometricAuthentication` for `BiometricStorage.read`to enforce biometric prompt in any case. Only for iOS and android.
+
+
 ## 5.1.1-dev.1
 
 * Improve `canAuthenticate` to include `InitOptions` to decide for which authenticaiton type to check.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -258,8 +258,7 @@ class StorageActions extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.spaceAround,
+    return Wrap(
       children: <Widget>[
         ElevatedButton(
           child: const Text('read'),
@@ -267,6 +266,25 @@ class StorageActions extends StatelessWidget {
             _logger.fine('reading from ${storageFile.name}');
             try {
               final result = await storageFile.read();
+              _logger.fine('read: {$result}');
+            } on AuthException catch (e) {
+              if (e.code == AuthExceptionCode.userCanceled) {
+                _logger.info('User canceled.');
+                return;
+              }
+              rethrow;
+            }
+          },
+        ),
+        ElevatedButton(
+          child: const Text('read with force'),
+          onPressed: () async {
+            _logger.fine(
+                'reading with forceBiometricAuthentication from ${storageFile.name}');
+            try {
+              final result = await storageFile.read(
+                forceBiometricAuthentication: true,
+              );
               _logger.fine('read: {$result}');
             } on AuthException catch (e) {
               if (e.code == AuthExceptionCode.userCanceled) {

--- a/lib/src/biometric_storage.dart
+++ b/lib/src/biometric_storage.dart
@@ -272,11 +272,18 @@ abstract class BiometricStorage extends PlatformInterface {
     PromptInfo promptInfo = PromptInfo.defaultValues,
   });
 
+  /// Reads the content of a secure storage file identified by [name].
+  ///
+  /// Returns the stored string content or null.
+  /// If [forceBiometricAuthentication] is set to true, show biometric prompt
+  /// even auth validity duration is not expired yet.
+  /// Only works on ios and android.
   @protected
   Future<String?> read(
     String name,
-    PromptInfo promptInfo,
-  );
+    PromptInfo promptInfo, {
+    bool forceBiometricAuthentication = false,
+  });
 
   @protected
   Future<bool?> delete(
@@ -396,10 +403,12 @@ class MethodChannelBiometricStorage extends BiometricStorage {
   @override
   Future<String?> read(
     String name,
-    PromptInfo promptInfo,
-  ) =>
+    PromptInfo promptInfo, {
+    bool forceBiometricAuthentication = false,
+  }) =>
       _transformErrors(_channel.invokeMethod<String>('read', <String, dynamic>{
         'name': name,
+        'forceBiometricAuthentication': forceBiometricAuthentication,
         ..._promptInfoForCurrentPlatform(promptInfo),
       }));
 
@@ -491,8 +500,15 @@ class BiometricStorageFile {
 
   /// read from the secure file and returns the content.
   /// Will return `null` if file does not exist.
-  Future<String?> read({PromptInfo? promptInfo}) =>
-      _plugin.read(name, promptInfo ?? defaultPromptInfo);
+  Future<String?> read({
+    PromptInfo? promptInfo,
+    bool forceBiometricAuthentication = false,
+  }) =>
+      _plugin.read(
+        name,
+        promptInfo ?? defaultPromptInfo,
+        forceBiometricAuthentication: forceBiometricAuthentication,
+      );
 
   /// Write content of this file. Previous value will be overwritten.
   Future<void> write(String content, {PromptInfo? promptInfo}) =>

--- a/lib/src/biometric_storage_web.dart
+++ b/lib/src/biometric_storage_web.dart
@@ -46,8 +46,9 @@ class BiometricStoragePluginWeb extends BiometricStorage {
   @override
   Future<String?> read(
     String name,
-    PromptInfo promptInfo,
-  ) async {
+    PromptInfo promptInfo, {
+    bool forceBiometricAuthentication = false,
+  }) async {
     return web.window.localStorage.getItem(name);
   }
 

--- a/lib/src/biometric_storage_win32.dart
+++ b/lib/src/biometric_storage_win32.dart
@@ -65,8 +65,9 @@ class Win32BiometricStoragePlugin extends BiometricStorage {
   @override
   Future<String?> read(
     String name,
-    PromptInfo promptInfo,
-  ) async {
+    PromptInfo promptInfo, {
+    bool forceBiometricAuthentication = false,
+  }) async {
     _logger.finer('read($name)');
     final credPointer = calloc<Pointer<CREDENTIAL>>();
     final namePointer = TEXT(name);

--- a/macos/Classes/BiometricStorageImpl.swift
+++ b/macos/Classes/BiometricStorageImpl.swift
@@ -8,342 +8,349 @@ typealias StorageCallback = (Any?) -> Void
 typealias StorageError = (String, String?, Any?) -> Any
 
 struct StorageMethodCall {
-  let method: String
-  let arguments: Any?
+    let method: String
+    let arguments: Any?
 }
 
 class InitOptions {
-  init(params: [String: Any]) {
-    darwinTouchIDAuthenticationAllowableReuseDuration = params["darwinTouchIDAuthenticationAllowableReuseDurationSeconds"] as? Int
-    darwinTouchIDAuthenticationForceReuseContextDuration = params["darwinTouchIDAuthenticationForceReuseContextDurationSeconds"] as? Int
-    authenticationRequired = params["authenticationRequired"] as? Bool
-    darwinBiometricOnly = params["darwinBiometricOnly"] as? Bool
-  }
-  let darwinTouchIDAuthenticationAllowableReuseDuration: Int?
-  let darwinTouchIDAuthenticationForceReuseContextDuration: Int?
-  let authenticationRequired: Bool!
-  let darwinBiometricOnly: Bool!
+    init(params: [String: Any]) {
+        darwinTouchIDAuthenticationAllowableReuseDuration = params["darwinTouchIDAuthenticationAllowableReuseDurationSeconds"] as? Int
+        darwinTouchIDAuthenticationForceReuseContextDuration = params["darwinTouchIDAuthenticationForceReuseContextDurationSeconds"] as? Int
+        authenticationRequired = params["authenticationRequired"] as? Bool
+        darwinBiometricOnly = params["darwinBiometricOnly"] as? Bool
+    }
+    let darwinTouchIDAuthenticationAllowableReuseDuration: Int?
+    let darwinTouchIDAuthenticationForceReuseContextDuration: Int?
+    let authenticationRequired: Bool!
+    let darwinBiometricOnly: Bool!
 }
 
 class IOSPromptInfo {
-  init(params: [String: Any]) {
-    saveTitle = params["saveTitle"] as? String
-    accessTitle = params["accessTitle"] as? String
-  }
-  let saveTitle: String!
-  let accessTitle: String!
+    init(params: [String: Any]) {
+        saveTitle = params["saveTitle"] as? String
+        accessTitle = params["accessTitle"] as? String
+    }
+    let saveTitle: String!
+    let accessTitle: String!
 }
 
 private func hpdebug(_ message: String) {
-  print(message);
+    print(message);
 }
 
 class BiometricStorageImpl {
-  
-  init(storageError: @escaping StorageError, storageMethodNotImplemented: Any) {
-    self.storageError = storageError
-    self.storageMethodNotImplemented = storageMethodNotImplemented
-  }
-  
-  private var stores: [String: BiometricStorageFile] = [:]
-  private let storageError: StorageError
-  private let storageMethodNotImplemented: Any
-
-  private func storageError(code: String, message: String?, details: Any?) -> Any {
-    return storageError(code, message, details)
-  }
-
-  public func handle(_ call: StorageMethodCall, result: @escaping StorageCallback) {
     
-    func requiredArg<T>(_ name: String, _ cb: (T) -> Void) {
-      guard let args = call.arguments as? Dictionary<String, Any> else {
-        result(storageError(code: "InvalidArguments", message: "Invalid arguments \(String(describing: call.arguments))", details: nil))
-        return
-      }
-      guard let value = args[name] else {
-        result(storageError(code: "InvalidArguments", message: "Missing argument \(name)", details: nil))
-        return
-      }
-      guard let valueTyped = value as? T else {
-        result(storageError(code: "InvalidArguments", message: "Invalid argument for \(name): expected \(T.self) got \(value)", details: nil))
-        return
-      }
-      cb(valueTyped)
-      return
-    }
-    func requireStorage(_ name: String, _ cb: (BiometricStorageFile) -> Void) {
-      guard let file = stores[name] else {
-        result(storageError(code: "InvalidArguments", message: "Storage was not initialized \(name)", details: nil))
-        return
-      }
-      cb(file)
+    init(storageError: @escaping StorageError, storageMethodNotImplemented: Any) {
+        self.storageError = storageError
+        self.storageMethodNotImplemented = storageMethodNotImplemented
     }
     
-    if ("canAuthenticate" == call.method) {
-      canAuthenticate(result: result)
-    } else if ("init" == call.method) {
-      requiredArg("name") { name in
-        requiredArg("options") { options in
-          stores[name] = BiometricStorageFile(name: name, initOptions: InitOptions(params: options), storageError: storageError)
-        }
-      }
-      result(true)
-    } else if ("dispose" == call.method) {
-      // nothing to dispose
-      result(true)
-    } else if ("read" == call.method) {
-      requiredArg("name") { name in
-        requiredArg("iosPromptInfo") { promptInfo in
-          requireStorage(name) { file in
-            file.read(result, IOSPromptInfo(params: promptInfo))
-          }
-        }
-      }
-    } else if ("write" == call.method) {
-      requiredArg("name") { name in
-        requiredArg("content") { content in
-          requiredArg("iosPromptInfo") { promptInfo in
-            requireStorage(name) { file in
-              file.write(content, result, IOSPromptInfo(params: promptInfo))
+    private var stores: [String: BiometricStorageFile] = [:]
+    private let storageError: StorageError
+    private let storageMethodNotImplemented: Any
+    
+    private func storageError(code: String, message: String?, details: Any?) -> Any {
+        return storageError(code, message, details)
+    }
+    
+    public func handle(_ call: StorageMethodCall, result: @escaping StorageCallback) {
+        
+        func requiredArg<T>(_ name: String, _ cb: (T) -> Void) {
+            guard let args = call.arguments as? Dictionary<String, Any> else {
+                result(storageError(code: "InvalidArguments", message: "Invalid arguments \(String(describing: call.arguments))", details: nil))
+                return
             }
-          }
+            guard let value = args[name] else {
+                result(storageError(code: "InvalidArguments", message: "Missing argument \(name)", details: nil))
+                return
+            }
+            guard let valueTyped = value as? T else {
+                result(storageError(code: "InvalidArguments", message: "Invalid argument for \(name): expected \(T.self) got \(value)", details: nil))
+                return
+            }
+            cb(valueTyped)
+            return
         }
-      }
-    } else if ("delete" == call.method) {
-      requiredArg("name") { name in
-        requiredArg("iosPromptInfo") { promptInfo in
-          requireStorage(name) { file in
-            file.delete(result, IOSPromptInfo(params: promptInfo))
-          }
+        func requireStorage(_ name: String, _ cb: (BiometricStorageFile) -> Void) {
+            guard let file = stores[name] else {
+                result(storageError(code: "InvalidArguments", message: "Storage was not initialized \(name)", details: nil))
+                return
+            }
+            cb(file)
         }
-      }
-    } else {
-      result(storageMethodNotImplemented)
+        
+        if ("canAuthenticate" == call.method) {
+            canAuthenticate(result: result)
+        } else if ("init" == call.method) {
+            requiredArg("name") { name in
+                requiredArg("options") { options in
+                    stores[name] = BiometricStorageFile(name: name, initOptions: InitOptions(params: options), storageError: storageError)
+                }
+            }
+            result(true)
+        } else if ("dispose" == call.method) {
+            // nothing to dispose
+            result(true)
+        } else if ("read" == call.method) {
+            requiredArg("name") { name in
+                requiredArg("forceBiometricAuthentication") { forceBiometricAuthentication in
+                    requiredArg("iosPromptInfo") { promptInfo in
+                        requireStorage(name) { file in
+                            file.read(result, IOSPromptInfo(params: promptInfo), forceBiometricAuthentication)
+                        }
+                    }
+                }
+            }
+        } else if ("write" == call.method) {
+            requiredArg("name") { name in
+                requiredArg("content") { content in
+                    requiredArg("iosPromptInfo") { promptInfo in
+                        requireStorage(name) { file in
+                            file.write(content, result, IOSPromptInfo(params: promptInfo))
+                        }
+                    }
+                }
+            }
+        } else if ("delete" == call.method) {
+            requiredArg("name") { name in
+                requiredArg("iosPromptInfo") { promptInfo in
+                    requireStorage(name) { file in
+                        file.delete(result, IOSPromptInfo(params: promptInfo))
+                    }
+                }
+            }
+        } else {
+            result(storageMethodNotImplemented)
+        }
     }
-  }
-  
-
-  private func canAuthenticate(result: @escaping StorageCallback) {
-    var error: NSError?
-    let context = LAContext()
-    if context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error) {
-      result("Success")
-      return
+    
+    
+    private func canAuthenticate(result: @escaping StorageCallback) {
+        var error: NSError?
+        let context = LAContext()
+        if context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error) {
+            result("Success")
+            return
+        }
+        guard let err = error else {
+            result("ErrorUnknown")
+            return
+        }
+        let laError = LAError(_nsError: err)
+        NSLog("LAError: \(laError)");
+        switch laError.code {
+        case .touchIDNotAvailable:
+            result("ErrorHwUnavailable")
+            break;
+        case .passcodeNotSet:
+            result("ErrorPasscodeNotSet")
+            break;
+        case .touchIDNotEnrolled:
+            result("ErrorNoBiometricEnrolled")
+            break;
+        case .invalidContext: fallthrough
+        default:
+            result("ErrorUnknown")
+            break;
+        }
     }
-    guard let err = error else {
-      result("ErrorUnknown")
-      return
-    }
-    let laError = LAError(_nsError: err)
-    NSLog("LAError: \(laError)");
-    switch laError.code {
-    case .touchIDNotAvailable:
-      result("ErrorHwUnavailable")
-      break;
-    case .passcodeNotSet:
-      result("ErrorPasscodeNotSet")
-      break;
-    case .touchIDNotEnrolled:
-      result("ErrorNoBiometricEnrolled")
-      break;
-    case .invalidContext: fallthrough
-    default:
-      result("ErrorUnknown")
-      break;
-    }
-  }
 }
 
 typealias StoredContext = (context: LAContext, expireAt: Date)
 
 class BiometricStorageFile {
-  private let name: String
-  private let initOptions: InitOptions
-  private var _context: StoredContext?
-  private var context: LAContext {
-    get {
-      if let context = _context {
-        if context.expireAt.timeIntervalSinceNow < 0 {
-          // already expired.
-          _context = nil
+    private let name: String
+    private let initOptions: InitOptions
+    private var _context: StoredContext?
+    private var context: LAContext {
+        get {
+            if let context = _context {
+                if context.expireAt.timeIntervalSinceNow < 0 {
+                    // already expired.
+                    _context = nil
+                } else {
+                    return context.context
+                }
+            }
+            
+            let context = LAContext()
+            if (initOptions.authenticationRequired) {
+                if let duration = initOptions.darwinTouchIDAuthenticationAllowableReuseDuration {
+                    if #available(OSX 10.12, *) {
+                        context.touchIDAuthenticationAllowableReuseDuration = Double(duration)
+                    } else {
+                        // Fallback on earlier versions
+                        hpdebug("Pre OSX 10.12 no touchIDAuthenticationAllowableReuseDuration available. ignoring.")
+                    }
+                }
+                
+                if let duration = initOptions.darwinTouchIDAuthenticationForceReuseContextDuration {
+                    _context = (context: context, expireAt: Date(timeIntervalSinceNow: Double(duration)))
+                }
+            }
+            return context
+        }
+    }
+    private let storageError: StorageError
+    
+    init(name: String, initOptions: InitOptions, storageError: @escaping StorageError) {
+        self.name = name
+        self.initOptions = initOptions
+        self.storageError = storageError
+    }
+    
+    private func baseQuery(_ result: @escaping StorageCallback) -> [String: Any]? {
+        var query = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "flutter_biometric_storage",
+            kSecAttrAccount as String: name,
+        ] as [String : Any]
+        if initOptions.authenticationRequired {
+            guard let access = accessControl(result) else {
+                return nil
+            }
+            if #available(iOS 13.0, macOS 10.15, *) {
+                query[kSecUseDataProtectionKeychain as String] = true
+            }
+            query[kSecAttrAccessControl as String] = access
+        }
+        return query
+    }
+    
+    private func accessControl(_ result: @escaping StorageCallback) -> SecAccessControl? {
+        let accessControlFlags: SecAccessControlCreateFlags
+        
+        if initOptions.darwinBiometricOnly {
+            if #available(iOS 11.3, *) {
+                accessControlFlags =  .biometryCurrentSet
+            } else {
+                accessControlFlags = .touchIDCurrentSet
+            }
         } else {
-          return context.context
-        }
-      }
-      
-      let context = LAContext()
-      if (initOptions.authenticationRequired) {
-        if let duration = initOptions.darwinTouchIDAuthenticationAllowableReuseDuration {
-          if #available(OSX 10.12, *) {
-            context.touchIDAuthenticationAllowableReuseDuration = Double(duration)
-          } else {
-            // Fallback on earlier versions
-            hpdebug("Pre OSX 10.12 no touchIDAuthenticationAllowableReuseDuration available. ignoring.")
-          }
+            accessControlFlags = .userPresence
         }
         
-        if let duration = initOptions.darwinTouchIDAuthenticationForceReuseContextDuration {
-          _context = (context: context, expireAt: Date(timeIntervalSinceNow: Double(duration)))
+        //      access = SecAccessControlCreateWithFlags(nil,
+        //                                               kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+        //                                               accessControlFlags,
+        //                                               &error)
+        var error: Unmanaged<CFError>?
+        guard let access = SecAccessControlCreateWithFlags(
+            nil, // Use the default allocator.
+            kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly,
+            accessControlFlags,
+            &error) else {
+            hpdebug("Error while creating access control flags. \(String(describing: error))")
+            result(storageError("writing data", "error writing data", "\(String(describing: error))"));
+            return nil
         }
-      }
-      return context
-    }
-  }
-  private let storageError: StorageError
-
-  init(name: String, initOptions: InitOptions, storageError: @escaping StorageError) {
-    self.name = name
-    self.initOptions = initOptions
-    self.storageError = storageError
-  }
-  
-  private func baseQuery(_ result: @escaping StorageCallback) -> [String: Any]? {
-    var query = [
-      kSecClass as String: kSecClassGenericPassword,
-      kSecAttrService as String: "flutter_biometric_storage",
-      kSecAttrAccount as String: name,
-    ] as [String : Any]
-    if initOptions.authenticationRequired {
-      guard let access = accessControl(result) else {
-        return nil
-      }
-      if #available(iOS 13.0, macOS 10.15, *) {
-        query[kSecUseDataProtectionKeychain as String] = true
-      }
-      query[kSecAttrAccessControl as String] = access
-    }
-    return query
-  }
-  
-  private func accessControl(_ result: @escaping StorageCallback) -> SecAccessControl? {
-    let accessControlFlags: SecAccessControlCreateFlags
-    
-    if initOptions.darwinBiometricOnly {
-      if #available(iOS 11.3, *) {
-        accessControlFlags =  .biometryCurrentSet
-      } else {
-        accessControlFlags = .touchIDCurrentSet
-      }
-    } else {
-      accessControlFlags = .userPresence
-    }
         
-//      access = SecAccessControlCreateWithFlags(nil,
-//                                               kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
-//                                               accessControlFlags,
-//                                               &error)
-    var error: Unmanaged<CFError>?
-    guard let access = SecAccessControlCreateWithFlags(
-      nil, // Use the default allocator.
-      kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly,
-      accessControlFlags,
-      &error) else {
-      hpdebug("Error while creating access control flags. \(String(describing: error))")
-      result(storageError("writing data", "error writing data", "\(String(describing: error))"));
-      return nil
-    }
-
-    return access
-  }
-  
-  func read(_ result: @escaping StorageCallback, _ promptInfo: IOSPromptInfo) {
-
-    guard var query = baseQuery(result) else {
-      return;
-    }
-    query[kSecMatchLimit as String] = kSecMatchLimitOne
-    query[kSecUseOperationPrompt as String] = promptInfo.accessTitle
-    query[kSecReturnAttributes as String] = true
-    query[kSecReturnData as String] = true
-    query[kSecUseAuthenticationContext as String] = context
-    
-    var item: CFTypeRef?
-    
-    let status = SecItemCopyMatching(query as CFDictionary, &item)
-    guard status != errSecItemNotFound else {
-      result(nil)
-      return
-    }
-    guard status == errSecSuccess else {
-      handleOSStatusError(status, result, "Error retrieving item. \(status)")
-      return
-    }
-    guard let existingItem = item as? [String : Any],
-      let data = existingItem[kSecValueData as String] as? Data,
-      let dataString = String(data: data, encoding: String.Encoding.utf8)
-      else {
-        result(storageError("RetrieveError", "Unexpected data.", nil))
-        return
-    }
-    result(dataString)
-  }
-  
-  func delete(_ result: @escaping StorageCallback, _ promptInfo: IOSPromptInfo) {
-    guard let query = baseQuery(result) else {
-      return;
-    }
-    //    query[kSecMatchLimit as String] = kSecMatchLimitOne
-    //    query[kSecReturnData as String] = true
-    let status = SecItemDelete(query as CFDictionary)
-    if status == errSecSuccess {
-      result(true)
-      return
-    }
-    if status == errSecItemNotFound {
-      hpdebug("Item not in keychain. Nothing to delete.")
-      result(true)
-      return
-    }
-    handleOSStatusError(status, result, "writing data")
-  }
-  
-  func write(_ content: String, _ result: @escaping StorageCallback, _ promptInfo: IOSPromptInfo) {
-    guard var query = baseQuery(result) else {
-      return;
-    }
-
-    if (initOptions.authenticationRequired) {
-      query.merge([
-        kSecUseAuthenticationContext as String: context,
-      ]) { (_, new) in new }
-      if let operationPrompt = promptInfo.saveTitle {
-        query[kSecUseOperationPrompt as String] = operationPrompt
-      }
-    } else {
-      hpdebug("No authentication required for \(name)")
-    }
-    query.merge([
-      //      kSecMatchLimit as String: kSecMatchLimitOne,
-      kSecValueData as String: content.data(using: String.Encoding.utf8) as Any,
-    ]) { (_, new) in new }
-    var status = SecItemAdd(query as CFDictionary, nil)
-    if (status == errSecDuplicateItem) {
-      hpdebug("Value already exists. updating.")
-      let update = [kSecValueData as String: query[kSecValueData as String]]
-      query.removeValue(forKey: kSecValueData as String)
-      status = SecItemUpdate(query as CFDictionary, update as CFDictionary)
-    }
-    guard status == errSecSuccess else {
-      handleOSStatusError(status, result, "writing data")
-      return
-    }
-    result(nil)
-  }
-  
-  private func handleOSStatusError(_ status: OSStatus, _ result: @escaping StorageCallback, _ message: String) {
-    var errorMessage: String? = nil
-    if #available(iOS 11.3, OSX 10.12, *) {
-      errorMessage = SecCopyErrorMessageString(status, nil) as String?
-    }
-    let code: String
-    switch status {
-    case errSecUserCanceled:
-      code = "AuthError:UserCanceled"
-    default:
-      code = "SecurityError"
+        return access
     }
     
-    result(storageError(code, "Error while \(message): \(status): \(errorMessage ?? "Unknown")", nil))
-  }
-  
+    func read(_ result: @escaping StorageCallback, _ promptInfo: IOSPromptInfo, _ forceBiometricAuthentication: Bool) {
+        if(forceBiometricAuthentication){
+            // invalidate current LAContext to enforce recreation of LAContext in context getter.
+            _context = nil
+        }
+        
+        
+        guard var query = baseQuery(result) else {
+            return;
+        }
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        query[kSecUseOperationPrompt as String] = promptInfo.accessTitle
+        query[kSecReturnAttributes as String] = true
+        query[kSecReturnData as String] = true
+        query[kSecUseAuthenticationContext as String] = context
+        
+        var item: CFTypeRef?
+        
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status != errSecItemNotFound else {
+            result(nil)
+            return
+        }
+        guard status == errSecSuccess else {
+            handleOSStatusError(status, result, "Error retrieving item. \(status)")
+            return
+        }
+        guard let existingItem = item as? [String : Any],
+              let data = existingItem[kSecValueData as String] as? Data,
+              let dataString = String(data: data, encoding: String.Encoding.utf8)
+        else {
+            result(storageError("RetrieveError", "Unexpected data.", nil))
+            return
+        }
+        result(dataString)
+    }
+    
+    func delete(_ result: @escaping StorageCallback, _ promptInfo: IOSPromptInfo) {
+        guard let query = baseQuery(result) else {
+            return;
+        }
+        //    query[kSecMatchLimit as String] = kSecMatchLimitOne
+        //    query[kSecReturnData as String] = true
+        let status = SecItemDelete(query as CFDictionary)
+        if status == errSecSuccess {
+            result(true)
+            return
+        }
+        if status == errSecItemNotFound {
+            hpdebug("Item not in keychain. Nothing to delete.")
+            result(true)
+            return
+        }
+        handleOSStatusError(status, result, "writing data")
+    }
+    
+    func write(_ content: String, _ result: @escaping StorageCallback, _ promptInfo: IOSPromptInfo) {
+        guard var query = baseQuery(result) else {
+            return;
+        }
+        
+        if (initOptions.authenticationRequired) {
+            query.merge([
+                kSecUseAuthenticationContext as String: context,
+            ]) { (_, new) in new }
+            if let operationPrompt = promptInfo.saveTitle {
+                query[kSecUseOperationPrompt as String] = operationPrompt
+            }
+        } else {
+            hpdebug("No authentication required for \(name)")
+        }
+        query.merge([
+            //      kSecMatchLimit as String: kSecMatchLimitOne,
+            kSecValueData as String: content.data(using: String.Encoding.utf8) as Any,
+        ]) { (_, new) in new }
+        var status = SecItemAdd(query as CFDictionary, nil)
+        if (status == errSecDuplicateItem) {
+            hpdebug("Value already exists. updating.")
+            let update = [kSecValueData as String: query[kSecValueData as String]]
+            query.removeValue(forKey: kSecValueData as String)
+            status = SecItemUpdate(query as CFDictionary, update as CFDictionary)
+        }
+        guard status == errSecSuccess else {
+            handleOSStatusError(status, result, "writing data")
+            return
+        }
+        result(nil)
+    }
+    
+    private func handleOSStatusError(_ status: OSStatus, _ result: @escaping StorageCallback, _ message: String) {
+        var errorMessage: String? = nil
+        if #available(iOS 11.3, OSX 10.12, *) {
+            errorMessage = SecCopyErrorMessageString(status, nil) as String?
+        }
+        let code: String
+        switch status {
+        case errSecUserCanceled:
+            code = "AuthError:UserCanceled"
+        default:
+            code = "SecurityError"
+        }
+        
+        result(storageError(code, "Error while \(message): \(status): \(errorMessage ?? "Unknown")", nil))
+    }
+    
 }


### PR DESCRIPTION
For my issue [129](https://github.com/authpass/biometric_storage/issues/129) I created a PR to always show biometric prompt in certain situations. 
On Android check if user requires authentication is skipped, when forceBiometricAuthentication is true.
On iOS LAContext is reseted, when forceBiometricAuthentication is true.

Also updated Example app to show effect of the flag and changelog.