### PR TITLE
support BIOMETRIC_WEAK

### DIFF
--- a/android/src/main/kotlin/design/codeux/biometric_storage/BiometricStoragePlugin.kt
+++ b/android/src/main/kotlin/design/codeux/biometric_storage/BiometricStoragePlugin.kt
@@ -333,9 +333,9 @@ class BiometricStoragePlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
         }
         val response = biometricManager.canAuthenticate(
             if (initOptions.androidBiometricOnly) {
-                BIOMETRIC_STRONG
+                BIOMETRIC_STRONG or BIOMETRIC_WEAK
             } else {
-                DEVICE_CREDENTIAL or BIOMETRIC_STRONG
+                DEVICE_CREDENTIAL or BIOMETRIC_STRONG or BIOMETRIC_WEAK
             }
         )
         return CanAuthenticateResponse.values().firstOrNull { it.code == response }


### PR DESCRIPTION
Support BIOMETRIC_WEAK during the authentication process as on some devices BIOMETRIC_STRONG is not working. TouchId will work even if we setAllowedAuthenticators(BIOMETRIC_STRONG) as here BIOMETRIC_WEAK is not supported