### PR TITLE
Add a deleteAndDispose API to allow storage reinitialisation at runtime

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -120,53 +120,92 @@ class MyAppState extends State<MyApp> {
         body: Column(
           children: [
             const Text('Methods:'),
-            ElevatedButton(
-              child: const Text('init'),
-              onPressed: () async {
-                _logger.finer('Initializing $baseName');
-                final authStorageSupport =
-                    await _checkAuthenticate(_authStorageInitOptions);
-                if (authStorageSupport == CanAuthenticateResponse.unsupported) {
-                  _logger.severe(
-                      'Unable to use authenticate. Unable to get storage.');
-                  return;
-                }
-                final supportsAuthenticated = authStorageSupport ==
-                        CanAuthenticateResponse.success ||
-                    authStorageSupport == CanAuthenticateResponse.statusUnknown;
-                if (supportsAuthenticated) {
-                  _authStorage = await BiometricStorage().getStorage(
-                    '${baseName}_authenticated',
-                    options: _authStorageInitOptions,
-                  );
-                }
-                _storage = await BiometricStorage()
-                    .getStorage('${baseName}_unauthenticated',
-                        options: StorageFileInitOptions(
-                          authenticationRequired: false,
-                        ));
-                final supportsCustomPrompt =
-                    await _checkAuthenticate(_customPromptInitOptions);
-                if (supportsCustomPrompt == CanAuthenticateResponse.success) {
-                  _customPrompt = await BiometricStorage()
-                      .getStorage('${baseName}_customPrompt',
-                          options: _customPromptInitOptions,
-                          promptInfo: const PromptInfo(
-                            iosPromptInfo: IosPromptInfo(
-                              saveTitle: 'Custom save title',
-                              accessTitle: 'Custom access title.',
-                            ),
-                            androidPromptInfo: AndroidPromptInfo(
-                              title: 'Custom title',
-                              subtitle: 'Custom subtitle',
-                              description: 'Custom description',
-                              negativeButton: 'Nope!',
-                            ),
-                          ));
-                }
-                setState(() {});
-                _logger.info('initiailzed $baseName');
-              },
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: [
+                ElevatedButton(
+                  child: const Text('init'),
+                  onPressed: () async {
+                    _logger.finer('Initializing $baseName');
+                    final authStorageSupport =
+                        await _checkAuthenticate(_authStorageInitOptions);
+                    if (authStorageSupport ==
+                        CanAuthenticateResponse.unsupported) {
+                      _logger.severe(
+                          'Unable to use authenticate. Unable to get storage.');
+                      return;
+                    }
+                    final supportsAuthenticated =
+                        authStorageSupport == CanAuthenticateResponse.success ||
+                            authStorageSupport ==
+                                CanAuthenticateResponse.statusUnknown;
+                    if (supportsAuthenticated) {
+                      _authStorage = await BiometricStorage().getStorage(
+                        '${baseName}_authenticated',
+                        options: _authStorageInitOptions,
+                      );
+                    }
+                    _storage = await BiometricStorage()
+                        .getStorage('${baseName}_unauthenticated',
+                            options: StorageFileInitOptions(
+                              authenticationRequired: false,
+                            ));
+                    final supportsCustomPrompt =
+                        await _checkAuthenticate(_customPromptInitOptions);
+                    if (supportsCustomPrompt ==
+                        CanAuthenticateResponse.success) {
+                      _customPrompt = await BiometricStorage()
+                          .getStorage('${baseName}_customPrompt',
+                              options: _customPromptInitOptions,
+                              promptInfo: const PromptInfo(
+                                iosPromptInfo: IosPromptInfo(
+                                  saveTitle: 'Custom save title',
+                                  accessTitle: 'Custom access title.',
+                                ),
+                                androidPromptInfo: AndroidPromptInfo(
+                                  title: 'Custom title',
+                                  subtitle: 'Custom subtitle',
+                                  description: 'Custom description',
+                                  negativeButton: 'Nope!',
+                                ),
+                              ));
+                    }
+                    setState(() {});
+                    _logger.info('initialized $baseName');
+                  },
+                ),
+                ElevatedButton(
+                  child: const Text('Delete and dispose all'),
+                  onPressed: () async {
+                    _logger.info('Deleting and disposing all storages');
+                    try {
+                      if (_authStorage != null) {
+                        await _authStorage!.deleteAndDispose();
+                        _authStorage = null;
+                        _logger.finer(
+                            'Deleted and disposed authenticated storage');
+                      }
+                      if (_storage != null) {
+                        await _storage!.deleteAndDispose();
+                        _storage = null;
+                        _logger.finer(
+                            'Deleted and disposed unauthenticated storage');
+                      }
+                      if (_customPrompt != null) {
+                        await _customPrompt!.deleteAndDispose();
+                        _customPrompt = null;
+                        _logger.finer(
+                            'Deleted and disposed custom prompt storage');
+                      }
+                      setState(() {});
+                      _logger.info('All storages deleted and disposed');
+                    } catch (e) {
+                      _logger
+                          .severe('Error deleting and disposing storages: $e');
+                    }
+                  },
+                ),
+              ],
             ),
             ...?_appArmorButton(),
             ...(_authStorage == null

--- a/lib/src/biometric_storage.dart
+++ b/lib/src/biometric_storage.dart
@@ -290,6 +290,12 @@ abstract class BiometricStorage extends PlatformInterface {
     String content,
     PromptInfo promptInfo,
   );
+
+  @protected
+  Future<void> dispose(
+    String name,
+    PromptInfo promptInfo,
+  );
 }
 
 class MethodChannelBiometricStorage extends BiometricStorage {
@@ -425,6 +431,14 @@ class MethodChannelBiometricStorage extends BiometricStorage {
         ..._promptInfoForCurrentPlatform(promptInfo),
       }));
 
+  @override
+  Future<void> dispose(String name, PromptInfo promptInfo) => _transformErrors(
+        _channel.invokeMethod('dispose', <String, dynamic>{
+          'name': name,
+          ..._promptInfoForCurrentPlatform(promptInfo),
+        }),
+      );
+
   Map<String, dynamic> _promptInfoForCurrentPlatform(PromptInfo promptInfo) {
     // Don't expose Android configurations to other platforms
     if (Platform.isAndroid) {
@@ -501,4 +515,12 @@ class BiometricStorageFile {
   /// Delete the content of this storage.
   Future<void> delete({PromptInfo? promptInfo}) =>
       _plugin.delete(name, promptInfo ?? defaultPromptInfo);
+
+  /// Delete the content of this storage and dispose of the storage instance.
+  /// After calling this method, this BiometricStorageFile instance should not be used.
+  /// A subsequent call to BiometricStorage().getStorage() with the same name will create a new instance.
+  Future<void> deleteAndDispose({PromptInfo? promptInfo}) async {
+    await delete(promptInfo: promptInfo);
+    await _plugin.dispose(name, promptInfo ?? defaultPromptInfo);
+  }
 }

--- a/lib/src/biometric_storage_web.dart
+++ b/lib/src/biometric_storage_web.dart
@@ -59,4 +59,9 @@ class BiometricStoragePluginWeb extends BiometricStorage {
   ) async {
     web.window.localStorage.setItem(name, content);
   }
+
+  @override
+  Future<void> dispose(String name, PromptInfo promptInfo) async {
+    // Nothing to dispose for web implementation
+  }
 }

--- a/lib/src/biometric_storage_win32.dart
+++ b/lib/src/biometric_storage_win32.dart
@@ -133,4 +133,9 @@ class Win32BiometricStoragePlugin extends BiometricStorage {
       _logger.fine('free done');
     }
   }
+
+  @override
+  Future<void> dispose(String name, PromptInfo promptInfo) async {
+    // Nothing to dispose for Win32 implementation
+  }
 }


### PR DESCRIPTION
Following from our old discussion (#75) about the mismatch between the intended usage of the `forceInit` option and my understanding of it, this PR introduces the deleteAndDispose API so that library consumers can reinitialise a storage with a different configuration (e.g. authentication grace period).

This is part of the fork consolidation efforts in issue #137