### PR TITLE
Allow library consumer to choose whether to enable Android StrongBox

### DIFF
--- a/android/src/main/kotlin/design/codeux/biometric_storage/BiometricStorageFile.kt
+++ b/android/src/main/kotlin/design/codeux/biometric_storage/BiometricStorageFile.kt
@@ -15,7 +15,8 @@ private val logger = KotlinLogging.logger {}
 data class InitOptions(
     val androidAuthenticationValidityDuration: Duration? = null,
     val authenticationRequired: Boolean = true,
-    val androidBiometricOnly: Boolean = true
+    val androidBiometricOnly: Boolean = true,
+    val androidUseStrongBox: Boolean = true
 )
 
 class BiometricStorageFile(
@@ -39,7 +40,7 @@ class BiometricStorageFile(
     private val cryptographyManager = CryptographyManager {
         setUserAuthenticationRequired(options.authenticationRequired)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            val useStrongBox = context.packageManager.hasSystemFeature(
+            val useStrongBox = options.androidUseStrongBox && context.packageManager.hasSystemFeature(
                 PackageManager.FEATURE_STRONGBOX_KEYSTORE
             )
             setIsStrongBoxBacked(useStrongBox)

--- a/android/src/main/kotlin/design/codeux/biometric_storage/BiometricStoragePlugin.kt
+++ b/android/src/main/kotlin/design/codeux/biometric_storage/BiometricStoragePlugin.kt
@@ -211,6 +211,7 @@ class BiometricStoragePlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
                     androidAuthenticationValidityDuration = (it["androidAuthenticationValidityDurationSeconds"] as Int?)?.seconds,
                     authenticationRequired = it["authenticationRequired"] as Boolean,
                     androidBiometricOnly = it["androidBiometricOnly"] as Boolean,
+                    androidUseStrongBox = it["androidUseStrongBox"] as Boolean,
                 )
             } ?: InitOptions()
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -78,6 +78,7 @@ class MyAppState extends State<MyApp> {
     darwinBiometricOnly: false,
     darwinTouchIDAuthenticationForceReuseContextDuration:
         const Duration(seconds: 5),
+    androidUseStrongBox: false,
   );
 
   BiometricStorageFile? _authStorage;

--- a/lib/src/biometric_storage.dart
+++ b/lib/src/biometric_storage.dart
@@ -91,6 +91,7 @@ class StorageFileInitOptions {
         'use use androidAuthenticationValidityDuration, iosTouchIDAuthenticationAllowableReuseDuration or iosTouchIDAuthenticationForceReuseContextDuration instead')
     int authenticationValidityDurationSeconds = -1,
     this.authenticationRequired = true,
+    this.androidUseStrongBox = true,
     this.androidBiometricOnly = true,
     this.darwinBiometricOnly = true,
   })  : androidAuthenticationValidityDuration =
@@ -145,6 +146,15 @@ class StorageFileInitOptions {
   /// https://developer.apple.com/documentation/security/secaccesscontrolcreateflags/1392879-userpresence
   final bool darwinBiometricOnly;
 
+  /// Whether to use Android StrongBox when available.
+  /// Only affects Android API 28+ devices that have StrongBox hardware support.
+  /// When true and StrongBox is supported, keys will be stored in the more secure
+  /// Secure Element (isolated from the main CPU, etc.). When false, keys will use
+  /// the Trusted Execution Environment (TEE). The StrongBox/SE implementation is
+  /// broken on some devices, leading to crashes and data loss.
+  /// Defaults to `true` for backwards compatibility.
+  final bool androidUseStrongBox;
+
   Map<String, dynamic> toJson() => <String, dynamic>{
         'androidAuthenticationValidityDurationSeconds':
             androidAuthenticationValidityDuration?.inSeconds,
@@ -155,6 +165,7 @@ class StorageFileInitOptions {
         'authenticationRequired': authenticationRequired,
         'androidBiometricOnly': androidBiometricOnly,
         'darwinBiometricOnly': darwinBiometricOnly,
+        'androidUseStrongBox': androidUseStrongBox,
       };
 }
 


### PR DESCRIPTION
Given the earlier concern regarding the reliability of StrongBox on some physical devices (#76), but entirely unclear information on *which* devices, I still feel that it might be too early to enable StrongBox across the board.

This library still does so, and presumably has had very few or zero issues related to these device bugs. My current fork does not use StrongBox.

As part of the fork consolidation efforts in issue #137, I would like this PR to be merged so that:

1. Existing users of this library see no immediate difference (backwards compatible).
2. Developers migrating from my fork (like me) can choose to either enable StrongBox or retain the disabled state.
3. Migrations to/from a StrongBox backed store can be orchestrated by developers if/when required.
4. Developers will be able to quickly change whether they use StrongBox, perhaps based upon real world feedback from users with devices that crash when it is enabled, or just as a security enhancement when all physical devices with implementation bugs are no longer in active use.
5. Developers could even choose to decide upon the StrongBox feature via an exclude list of known bad devices, if such details ever become apparent to them.
6. Control of the option could potentially be exposed as a debug feature for app users to toggle if advised that production crashes or data loss may be caused by the use of the Secure Enclave.